### PR TITLE
Patch update for 5.0.2

### DIFF
--- a/dsjob/Readme.md
+++ b/dsjob/Readme.md
@@ -10,12 +10,13 @@ Last Updated: 2023-11-12
 CPDCTL and the  `dsjob`  tool are command-line interfaces (CLI) you can use to manage your  DataStage®  resources in IBM Cloud Pak for Data.
 
 ### Documentation:
-#### Latest : [DSJob Plugin 5.0.1](https://github.com/IBM/DataStage/tree/main/dsjob/dsjob.5.0.2.md)
+#### Latest : [DSJob Plugin 5.0.2](https://github.com/IBM/DataStage/tree/main/dsjob/dsjob.5.0.2.md)
 ### Binary
-#### [DSJob Plugin 5.0.1](https://github.com/IBM/cpdctl/releases/tag/v1.6.55)
+#### [DSJob Plugin 5.0.2](https://github.com/IBM/cpdctl/releases/tag/v1.6.55)
+#### [DSJob Plugin 5.0.2.1](https://github.com/IBM/cpdctl/releases/tag/v1.6.61)
 
 #### Other Releases
-[DSJob Plugin 5.0.0](https://github.com/IBM/DataStage/tree/main/dsjob/dsjob.5.0.1.md)
+[DSJob Plugin 5.0.1](https://github.com/IBM/DataStage/tree/main/dsjob/dsjob.5.0.1.md)
 
 [DSJob Plugin 5.0.0](https://github.com/IBM/DataStage/tree/main/dsjob/dsjob.5.0.0.md)
 
@@ -77,4 +78,4 @@ CPDCTL release build contains the dsjob plugin which is release for the mentione
 |5.0.0   | v1.6.6   |
 |5.0.1   | v1.6.29  |
 |5.0.2   | v1.6.55  |
-
+|5.0.2.1 | v1.6.61  |

--- a/dsjob/changelog.md
+++ b/dsjob/changelog.md
@@ -54,6 +54,13 @@ interface.
 [4.6.2](#462)
 [Documentation](https://github.com/IBM/DataStage/tree/main/dsjob/dsjob.4.6.2.md)
 
+## 5.0.2.1
+
+### Fixes
+ 
+ - `reset-pipeline-cache`. This command is now behind a toggle `ENABLE_DSJOB_RESETPIPELINECACHE`. This is to make sure that user must use the official `
+
+
 ## 5.0.2
 
 ### New commands

--- a/dsjob/dsjob.5.0.2.md
+++ b/dsjob/dsjob.5.0.2.md
@@ -1043,24 +1043,6 @@ logs from the latest run are printed.
 A status code is printed to the output. A status code of 0 indicates successful completion of
 the command.
 
-## Clearing Pipeline Cache
-
-The following command clears the pipeline cache without running the pipeline.
-
-```
-cpdctl dsjob reset-pipeline-cache {--project PROJECT | --project-id PROJID} {--name name | --id ID} [--job-name name | --job-id ID] [--run-id runid]
-```
-
--   `project`  is the name of the project that contains the pipeline.
--   `project-id`  is the id of the project. One of  `project`  or  `project-id`  must be specified.
--   `name`  is the name of the pipeline.
--   `id`  is the id of the pipeline. One of  `name`  or  `id`  must be specified.
--   `job-name`  is the name of the pipeline job. 
--   `job-id`  is the id of the pipeline  job. One of  `job-name`  or  `job-id`  must be specified.
--   `run-id`  is the id of a particular pipeline  job run. If not specified the last run of the pipeline job will be reset.
-
-This command does not reset nested pipelines.
-
 ## Imports and exports
 
 ### Importing
@@ -4490,21 +4472,3 @@ cpdctl dsjob clear-vault-cache
 Note: this command does not take arguments.
 
 
-
-## Clearing Pipeline Cache
-
-The following command clears the pipeline cache without running the pipeline.
-
-```
-cpdctl dsjob reset-pipeline-cache {--project PROJECT | --project-id PROJID} {--name name | --id ID} [--job-name name | --job-id ID] [--run-id runid]
-```
-
--   `project`  is the name of the project that contains the pipeline.
--   `project-id`  is the id of the project. One of  `project`  or  `project-id`  must be specified.
--   `name`  is the name of the pipeline.
--   `id`  is the id of the pipeline. One of  `name`  or  `id`  must be specified.
--   `job-name`  is the name of the pipeline job. 
--   `job-id`  is the id of the pipeline  job. One of  `job-name`  or  `job-id`  must be specified.
--   `run-id`  is the id of a particular pipeline  job run. If not specified the last run of the pipeline job will be reset.
-
-Note: this command does not reset the nested pipeline until that functionality available in the product.


### PR DESCRIPTION
Signed-off-by: Srini Brahmaroutu <srbrahma@us.ibm.com>

Remove pipeline cache commands from documentation as they should be used from pipeline plugin and not from dsjob plugin.