### PR TITLE
DS-37489: adding parameters for users to pass in security-opt and cap…

### DIFF
--- a/RemoteEngine/docker/README.md
+++ b/RemoteEngine/docker/README.md
@@ -82,6 +82,8 @@ While starting a remote engine, following optional flags can be used in addition
 1. `--home <value>`: Sets the target IBM Cloud enviroment to either `ypprod` (Dallas data center - default) or `frprod` (Frankfurt data center). The project associated with this engine instance must be in same data center.
 1. `--select-version`: Set to true if you want to choose a specific version of remote engine. By default, this flag is set to false and the latest version is used.
 1. `--version`: Version of the remote engine to use; default will use the latest version.
+1. `--security-opt <value>`: Specify the security-opt to be used to run the container.
+1. `--cap-drop <value>`: Specify the cap-drop to be used to run the container.
 1. `--set-user <username>`: Specify the username to be used to run the container. If not set, the current user is used.
 1. `--set-group <groupname>`: Specify the group to be used to run the container/
 1. `--mount-dir "</path/to/local_dir:/path/on/container>"`: Specify folder you want to mount on the container. This flag can be specified multiple times.

--- a/RemoteEngine/docker/dsengine.sh
+++ b/RemoteEngine/docker/dsengine.sh
@@ -15,7 +15,7 @@
 # constants
 #######################################################################
 # tool version
-TOOL_VERSION=1.0.3
+TOOL_VERSION=1.0.4
 TOOL_NAME='IBM DataStage Remote Engine'
 TOOL_SHORTNAME='DataStage Remote Engine'
 


### PR DESCRIPTION
…-drop options during container runtime

relates to https://github.ibm.com/DataStage/tracker/issues/37489

Tested by deploying the remote engine and checking the value of the security opt and cap drop values and also ran a flow for sanity check.