### PR TITLE
DS-46146: changing default volume directory to use $(pwd) instead of …

### DIFF
--- a/RemoteEngine/docker/dsengine.sh
+++ b/RemoteEngine/docker/dsengine.sh
@@ -15,7 +15,7 @@
 # constants
 #######################################################################
 # tool version
-TOOL_VERSION=1.0.8
+TOOL_VERSION=1.0.9
 TOOL_NAME='IBM DataStage Remote Engine'
 TOOL_SHORTNAME='DataStage Remote Engine'
 
@@ -33,7 +33,7 @@ DOCKER_CMD='docker'
 if ! [ -x "$(command -v docker)" ] && [ -x "$(command -v podman)" ]; then
     DOCKER_CMD='podman'
 fi
-DOCKER_VOLUMES_DIR='/tmp/docker/volumes'
+DOCKER_VOLUMES_DIR="$(pwd)/docker/volumes"
 MOUNT_DIRS=()
 SCRATCH_DIR_OVERRIDE='false'
 


### PR DESCRIPTION
…/tmp

relates to https://github.ibm.com/DataStage/tracker/issues/46146

Testing: created a remote engine on YPPROD and verified dsengine.sh script is using $(pwd) instead of /tmp and verified flows compiles and runs.