### PR TITLE
DS-48288: fixing docker script update command

### DIFF
--- a/RemoteEngine/docker/dsengine.sh
+++ b/RemoteEngine/docker/dsengine.sh
@@ -15,7 +15,7 @@
 # constants
 #######################################################################
 # tool version
-TOOL_VERSION=1.0.11
+TOOL_VERSION=1.0.12
 TOOL_NAME='IBM DataStage Remote Engine'
 TOOL_SHORTNAME='DataStage Remote Engine'
 
@@ -2188,10 +2188,10 @@ elif [[ ${ACTION} == "update" ]]; then
     fi
     DOCKER_VOLUMES_DIR=$(dirname "$DS_STORAGE_HOST_DIR")
     SCRATCH_BASE_DIR=$(dirname "$SCRATCH_DIR")
-    if [[ "$CONTAINER_CAP_DROP" == "[]" ]]; then
+    if [[ -z $CONTAINER_CAP_DROP ]] || [[ "$CONTAINER_CAP_DROP" == "[]" ]]; then
         CONTAINER_CAP_DROP="NOT_SET"
     fi
-    if [[ "$CONTAINER_SECURITY_OPT" == "[]" ]]; then
+    if [[ -z $CONTAINER_SECURITY_OPT ]] || [[ "$CONTAINER_SECURITY_OPT" == "[]" ]]; then
         CONTAINER_SECURITY_OPT="NOT_SET"
     fi
 


### PR DESCRIPTION
relates to https://github.ibm.com/DataStage/tracker/issues/48288

Testing: local testing using unset security-opt and cap-drop values and updating the remote engine to verify the security-opt and cap-drop gets set to NOT_SET on container startup