### PR TITLE
DS-49738: updating dsengine.sh script to delete and recreate old envi…

### DIFF
--- a/RemoteEngine/docker/dsengine.sh
+++ b/RemoteEngine/docker/dsengine.sh
@@ -15,7 +15,7 @@
 # constants
 #######################################################################
 # tool version
-TOOL_VERSION=1.0.18
+TOOL_VERSION=1.0.19
 TOOL_NAME='IBM DataStage Remote Engine'
 TOOL_SHORTNAME='DataStage Remote Engine'
 
@@ -1474,9 +1474,12 @@ patch_environment() {
     if [[ -z "${_project_env_patch_response_status}" || "${_project_env_patch_response_status}" != "200" ]]; then
         echo "Response: ${_project_env_patch_response}"
         echo ""
-        echo_error_and_exit "Failed to patch environment with id: ${PROJECT_ENV_ASSET_ID}."
+        echo "Unable to patch environment runtime with id: ${PROJECT_ENV_ASSET_ID}. Deleting environment runtime and recreating a new one ..."
+        remove_environment
+        create_environment
+    else
+        echo "Patched environment runtime with id: ${PROJECT_ENV_ASSET_ID}"
     fi
-    echo "Patched environment runtime with id: ${PROJECT_ENV_ASSET_ID}"
 }
 
 

--- a/RemoteEngine/docker/dsengine.sh
+++ b/RemoteEngine/docker/dsengine.sh
@@ -1474,9 +1474,8 @@ patch_environment() {
     if [[ -z "${_project_env_patch_response_status}" || "${_project_env_patch_response_status}" != "200" ]]; then
         echo "Response: ${_project_env_patch_response}"
         echo ""
-        echo "Unable to patch environment runtime with id: ${PROJECT_ENV_ASSET_ID}. Deleting environment runtime and recreating a new one ..."
-        remove_environment
-        create_environment
+        echo "WARNING: Unable to patch environment runtime with id: ${PROJECT_ENV_ASSET_ID}. Ignoring ..."
+        echo ""
     else
         echo "Patched environment runtime with id: ${PROJECT_ENV_ASSET_ID}"
     fi


### PR DESCRIPTION
…ronment runtime if it cannot be patched

relates to https://github.ibm.com/DataStage/tracker/issues/49738

Testing: reproduced issue and local testing verifying environment runtime is successfully deleted and recreated after failure to patch.