### PR TITLE
DS-49742: change the way dsengine restarts stopped containers

### DIFF
--- a/RemoteEngine/docker/dsengine.sh
+++ b/RemoteEngine/docker/dsengine.sh
@@ -15,7 +15,7 @@
 # constants
 #######################################################################
 # tool version
-TOOL_VERSION=1.0.23
+TOOL_VERSION=1.0.24
 TOOL_NAME='IBM DataStage Remote Engine'
 TOOL_SHORTNAME='DataStage Remote Engine'
 


### PR DESCRIPTION
relates to https://github.ibm.com/DataStage/tracker/issues/49742

Testing: created remote engine, stopped it, and tried starting it again with parameters and without parameters.