### PR TITLE
DS-55913: default PIDS_LIMIT to -1 when updating remote engine cannot…

### DIFF
--- a/RemoteEngine/docker/dsengine.sh
+++ b/RemoteEngine/docker/dsengine.sh
@@ -15,7 +15,7 @@
 # constants
 #######################################################################
 # tool version
-TOOL_VERSION=1.0.27
+TOOL_VERSION=1.0.28
 TOOL_NAME='IBM DataStage Remote Engine'
 TOOL_SHORTNAME='DataStage Remote Engine'
 
@@ -2484,8 +2484,12 @@ elif [[ ${ACTION} == "update" ]]; then
     [ -z $IVSPEC ] && "Could not retrieve IVSPEC from container ${PXRUNTIME_CONTAINER_NAME}"
     [ -z $PX_MEMORY ] && "Could not retrieve PX_MEMORY from container ${PXRUNTIME_CONTAINER_NAME}"
     [ -z $PX_CPUS ] && "Could not retrieve PX_CPUS from container ${PXRUNTIME_CONTAINER_NAME}"
-    [ -z $PIDS_LIMIT ] && PIDS_LIMIT='-1'
-    [ -z $REMOTE_ENGINE_PORT ] && REMOTE_ENGINE_PORT='9443'
+    if [[ -z $PIDS_LIMIT ]] || [[ $PIDS_LIMIT == '<nil>' ]]; then
+        PIDS_LIMIT='-1'
+    fi
+    if [[ -z $REMOTE_ENGINE_PORT ]] || [[ $REMOTE_ENGINE_PORT == '<nil>' ]]; then
+        REMOTE_ENGINE_PORT='9443'
+    fi
     [ -z $GATEWAY_URL ] && "Could not retrieve GATEWAY_URL from container ${PXRUNTIME_CONTAINER_NAME}"
     if [[ "${DATASTAGE_HOME}" == 'cp4d' ]]; then
         [ -z $ZEN_URL ] && "Could not retrieve ZEN_URL from container ${PXRUNTIME_CONTAINER_NAME}."


### PR DESCRIPTION
… find the value in container pt.2

relates to https://github.ibm.com/DataStage/tracker/issues/56138