### PR TITLE
Add progress field and name proxy cert file

### DIFF
--- a/RemoteEngine/kubernetes/launch.sh
+++ b/RemoteEngine/kubernetes/launch.sh
@@ -4,7 +4,7 @@
 # This script is a utility to install DataStage Remote Engine
 
 # tool version
-TOOL_VERSION=1.0.18
+TOOL_VERSION=1.0.19
 TOOL_NAME='IBM DataStage Remote Engine'
 
 kubernetesCLI="oc"
@@ -281,6 +281,10 @@ spec:
       - description: The status of PXRemoteEngine
         jsonPath: .status.dsStatus
         name: Status
+        type: string
+      - description: Progress percentage of PXRemoteEngine
+        jsonPath: .status.progress
+        name: Percent
         type: string
       - description: The age of PXRemoteEngine
         jsonPath: .metadata.creationTimestamp
@@ -701,7 +705,7 @@ create_proxy_secrets() {
     if [ ! -z $cacert_location ]; then
       if [ -f $cacert_location ]; then
         CURL_CMD="${CURL_CMD} --proxy-insecure"
-        $kubernetesCLI -n ${namespace} create secret generic connection-ca-certs --from-file=${cacert_location}
+        $kubernetesCLI -n ${namespace} create secret generic connection-ca-certs --from-file=remote_proxy_cert.pem=${cacert_location}
       else
         echo_error_and_exit "The specified proxy certificate $cacert_location is not found."
       fi


### PR DESCRIPTION
Add progress field column for pxre kind and name the proxy cert as remote_proxy_cert.pem in connection-ca-certs. The fixed name will be used for setting AWS_CA_FILE env, which is needed for awscmd to files to COS through a proxy with self-signed certificate.

```
% oc get pxre
NAME                  VERSION   RECONCILED   STATUS      PERCENT   AGE
wxdataintegration10   5.4.0     5.4.0        Completed   100%      18h
```